### PR TITLE
fix: shorten status description

### DIFF
--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -11,7 +11,7 @@ async function handlePullRequestChange (context) {
     sha: head.sha,
     state: status,
     target_url: 'https://github.com/apps/semantic-pull-request',
-    description: isSemantic ? 'good to go' : 'missing semantic commit message or PR title' ,
+    description: isSemantic ? 'good to go' : 'add semantic commit or PR title' ,
     context: 'Semantic Pull Request'
   }))
 }


### PR DESCRIPTION
Existing description is getting truncated:

<img width="714" alt="screen shot 2018-04-24 at 9 16 11 am" src="https://user-images.githubusercontent.com/2289/39200559-5d6f4854-47a1-11e8-922e-98f71214eaa0.png">

New one is shorter:

<img width="724" alt="screen shot 2018-04-24 at 9 17 11 am" src="https://user-images.githubusercontent.com/2289/39200567-619a2eda-47a1-11e8-829f-5749ffecd000.png">

