### PR TITLE
fix(is-semantic): update to latest parse-commit-message

### DIFF
--- a/lib/is-semantic-message.js
+++ b/lib/is-semantic-message.js
@@ -1,11 +1,10 @@
 const commitTypes = Object.keys(require('conventional-commit-types').types)
-const parseCommitMessage = require('parse-commit-message').parse
+const { validate } = require('parse-commit-message')
 
 module.exports = function isSemanticMessage (message) {
-  try {
-    const { type } = parseCommitMessage(message)
-    return commitTypes.includes(type)
-  } catch (e) {
-    return false
-  }
+  const { error, value: commits } = validate(message, true)
+  if (error) return false
+
+  const [result] = commits
+  return commitTypes.includes(result.header.type)
 }

--- a/lib/is-semantic-message.js
+++ b/lib/is-semantic-message.js
@@ -3,7 +3,10 @@ const { validate } = require('parse-commit-message')
 
 module.exports = function isSemanticMessage (message) {
   const { error, value: commits } = validate(message, true)
-  if (error) return false
+  if (error) {
+    console.error(error)
+    return false
+  }
 
   const [result] = commits
   return commitTypes.includes(result.header.type)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3239,12 +3239,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3259,17 +3261,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3386,7 +3391,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3398,6 +3404,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3412,6 +3419,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3419,12 +3427,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3443,6 +3453,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3523,7 +3534,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3535,6 +3547,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3656,6 +3669,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -579,11 +579,6 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
-    "arrayify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/arrayify/-/arrayify-1.0.0.tgz",
-      "integrity": "sha1-8GqYI1uO8UyhmVmSQRqf77TknPw="
-    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -1394,11 +1389,11 @@
       "dev": true
     },
     "collect-mentions": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/collect-mentions/-/collect-mentions-0.1.1.tgz",
-      "integrity": "sha512-seEeKufgpcHKbW41+o7EoW0hyjLAvjYRbFeAVgPUADTCfDMzFeMlXjFdAa5X5JThp/05Tpn3K2Xl/7r9a5BpHw==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/collect-mentions/-/collect-mentions-1.0.2.tgz",
+      "integrity": "sha512-/jRhzWp5bkZnvgtR+agXT0RvYKBXOl4uG+eKA6ip3tp1x+jRAV36jW2TceKutOeuEPjHKaQ6DJjeh5zvZF0fWQ==",
       "requires": {
-        "mentions-regex": "2.0.3"
+        "mentions-regex": "^2.0.3"
       }
     },
     "collection-visit": {
@@ -1790,6 +1785,11 @@
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw="
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -2627,6 +2627,11 @@
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
       "dev": true
     },
+    "esm": {
+      "version": "3.0.84",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.0.84.tgz",
+      "integrity": "sha512-SzSGoZc17S7P+12R9cg21Bdb7eybX25RnIeRZ80xZs+VZ3kdQKzqTp2k4hZJjR7p9l0186TTXSgrxzlMDBktlw=="
+    },
     "espree": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-4.0.0.tgz",
@@ -3234,12 +3239,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3254,17 +3261,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3381,7 +3391,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3393,6 +3404,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3407,6 +3419,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3414,12 +3427,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3438,6 +3453,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3518,7 +3534,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3530,6 +3547,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3651,6 +3669,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6354,12 +6373,21 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "parse-commit-message": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/parse-commit-message/-/parse-commit-message-1.1.2.tgz",
-      "integrity": "sha512-Qbo5hsgyHUklbDJeBMelKUKN9PEpJ1leEUSLziPPuC0NDNI5RCtynihLvQhhZUSv49aey+x6fdXLQlIIAuT4OQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/parse-commit-message/-/parse-commit-message-3.2.0.tgz",
+      "integrity": "sha512-LzkHT+I2cG+3v0iGnMNPda4qdZoTjiz40rOEdo7pd7gpE4YHXFDvF4dj2LuoMQX7Ykb3WlKZBfwLSKFHASvjGw==",
       "requires": {
-        "arrayify": "1.0.0",
-        "collect-mentions": "0.1.1"
+        "collect-mentions": "^1.0.2",
+        "dedent": "^0.7.0",
+        "esm": "^3.0.84",
+        "mixin-deep": "^2.0.0"
+      },
+      "dependencies": {
+        "mixin-deep": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-2.0.0.tgz",
+          "integrity": "sha512-2tAhDtV+OCFCeknyf2cJD5rD+xfvM2ax/RZ3iI1G67Eh6x5UxKJlGDVpmCX27y7WvuXpAkMHQs9ooaxIHIit+A=="
+        }
       }
     },
     "parse-github-url": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3239,14 +3239,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3261,20 +3259,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3391,8 +3386,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3404,7 +3398,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3419,7 +3412,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3427,14 +3419,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -3453,7 +3443,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3534,8 +3523,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3547,7 +3535,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3669,7 +3656,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -6373,9 +6359,9 @@
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "parse-commit-message": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/parse-commit-message/-/parse-commit-message-3.2.0.tgz",
-      "integrity": "sha512-LzkHT+I2cG+3v0iGnMNPda4qdZoTjiz40rOEdo7pd7gpE4YHXFDvF4dj2LuoMQX7Ykb3WlKZBfwLSKFHASvjGw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/parse-commit-message/-/parse-commit-message-3.2.1.tgz",
+      "integrity": "sha512-Qis/J5olChQS7UG/sPDc4fYX/GQvc33a1kxwq+Md42CSCexczXA1C4IR3rOziriYxYhptyBdaT2r7hs897UTLQ==",
       "requires": {
         "collect-mentions": "^1.0.2",
         "dedent": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "conventional-commit-types": "^2.2.0",
-    "parse-commit-message": "^3.2.0",
+    "parse-commit-message": "^3.2.1",
     "probot": "^7.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "conventional-commit-types": "^2.2.0",
-    "parse-commit-message": "^1.1.2",
+    "parse-commit-message": "^3.2.0",
     "probot": "^7.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
So yea. A lot has changed in v3, it's amazing!

Ii has validate, stringify and parse.

Validate runs `.check` in "loose" if I can call it that way. It checks for valid pattern like `<type>[scope]: <subject>`, so `foo bar baz` will fail. Also, checks if the scope is empty, so `fix(): bar qux` will fail too, but `fix: bar qux` won't. Empty body and empty footer are allowed (and that's what 3.1 and 3.2 are), because we rely behave like `git commit` seems to add empty new line, which can be seen in `git log` - after parsing. 

There is a huge amount of tests there, so it's guaranteed.

We use the `ret` option of `.validate` because we want to check further the commit type against the `conventional-commit-types`.