### PR TITLE
feat: add config option to only lint commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,12 @@ the following optional settings:
 
 ```yml
 # Always validate the PR title, and ignore the commits
-titleOnly: false
+titleOnly: true
+```
+
+```yml
+# Always validate all commits, and ignore the PR title
+commitsOnly: true
 ```
 
 ## License

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -3,29 +3,38 @@ module.exports = handlePullRequestChange
 const isSemanticMessage = require('./is-semantic-message')
 const getConfig = require('probot-config')
 
-async function commitsAreSemantic (context) {
+async function commitsAreSemantic (context, allCommits = false) {
   const commits = await context.github.pullRequests.getCommits(context.repo({
     number: context.payload.pull_request.number
   }))
 
   return commits.data
-    .map(element => element.commit)
-    .some(commit => isSemanticMessage(commit.message))
+    .map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message))
 }
 
 async function handlePullRequestChange (context, config) {
   const { title, head } = context.payload.pull_request
-  const { titleOnly } = getConfig(context, 'semantic.yml')
+  const { titleOnly, commitsOnly } = await getConfig(context, 'semantic.yml')
   const hasSemanticTitle = isSemanticMessage(title)
-  const hasSemanticCommits = await commitsAreSemantic(context)
-  const isSemantic = titleOnly
-    ? hasSemanticTitle
-    : hasSemanticTitle || hasSemanticCommits
+  const hasSemanticCommits = await commitsAreSemantic(context, commitsOnly)
+
+  let isSemantic
+
+  if (titleOnly) {
+    isSemantic = hasSemanticTitle
+  } else if (commitsOnly) {
+    isSemantic = hasSemanticCommits
+  } else {
+    isSemantic = hasSemanticTitle || hasSemanticCommits
+  }
+
   const state = isSemantic ? 'success' : 'pending'
 
   function getDescription () {
     if (hasSemanticTitle) return 'ready to be squashed'
     if (hasSemanticCommits) return 'ready to be merged or rebased'
+    if (titleOnly) return 'add a semantic PR title'
+    if (commitsOnly) return 'make sure every commit is semantic'
     return 'add a semantic commit or PR title'
   }
 


### PR DESCRIPTION
Useful when using Rebase + Merge as merge strategy.

Closes #31

-----
[View rendered README.md](https://github.com/stefanbuck/semantic-pull-requests/blob/feat-commitsOnly/README.md)