### PR TITLE
fix: add default options to ensure getConfig never returns null

### DIFF
--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -3,6 +3,11 @@ module.exports = handlePullRequestChange
 const isSemanticMessage = require('./is-semantic-message')
 const getConfig = require('probot-config')
 
+const DEFAULT_OPTS = {
+  titleOnly: false,
+  commitsOnly: false
+}
+
 async function commitsAreSemantic (context, allCommits = false) {
   const commits = await context.github.pullRequests.getCommits(context.repo({
     number: context.payload.pull_request.number
@@ -14,7 +19,7 @@ async function commitsAreSemantic (context, allCommits = false) {
 
 async function handlePullRequestChange (context, config) {
   const { title, head } = context.payload.pull_request
-  const { titleOnly, commitsOnly } = await getConfig(context, 'semantic.yml')
+  const { titleOnly, commitsOnly } = await getConfig(context, 'semantic.yml', DEFAULT_OPTS)
   const hasSemanticTitle = isSemanticMessage(title)
   const hasSemanticCommits = await commitsAreSemantic(context, commitsOnly)
 


### PR DESCRIPTION
In the case that `semantic.yml` does not exist, `getConfig` returns `null`, and the destructuring fails. This adds default options so that `getConfig` will never return `null`.

Prior to #33, we were incorrectly destructuring off the Promise returned from `getConfig` because we weren't `await`ing the Promise.