### PR TITLE
fix: fixing ready messages when using commitsOnly or titleOnly

### DIFF
--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -36,8 +36,8 @@ async function handlePullRequestChange (context, config) {
   const state = isSemantic ? 'success' : 'pending'
 
   function getDescription () {
-    if (hasSemanticTitle) return 'ready to be squashed'
-    if (hasSemanticCommits) return 'ready to be merged or rebased'
+    if (hasSemanticTitle && !commitsOnly) return 'ready to be squashed'
+    if (hasSemanticCommits && !titleOnly) return 'ready to be merged or rebased'
     if (titleOnly) return 'add a semantic PR title'
     if (commitsOnly) return 'make sure every commit is semantic'
     return 'add a semantic commit or PR title'


### PR DESCRIPTION
### Use case
In my config:

```yaml
titleOnly: true
```

I have a repo configured to only squash commit PRs and because of this, the title should always be valid.

I had a PR with some `semantic commits` but not a `semantic title`.

This PR should be blocked as the commits don't matter to me, only the title.

The status was OK, my PR got blocked.
But, the description was incorrectly showing: `Pending — ready to be merged or rebased`
When it should display: `Pending — add a semantic PR title`