### PR TITLE
feat: allow merge commit config

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ scopes:
   ...
 ```
 
+```yml
+# Allow use of Merge commits (eg on github: "Merge branch 'master' into feature/ride-unicorns")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowMergeCommits: true
+```
+
 ## License
 
 [Apache 2.0](LICENSE)

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -7,16 +7,17 @@ const DEFAULT_OPTS = {
   titleOnly: false,
   commitsOnly: false,
   titleAndCommits: false,
-  scopes: null
+  scopes: null,
+  allowMergeCommits: false
 }
 
-async function commitsAreSemantic (context, scopes, allCommits = false) {
+async function commitsAreSemantic (context, scopes, allCommits = false, allowMergeCommits) {
   const commits = await context.github.pullRequests.getCommits(context.repo({
     number: context.payload.pull_request.number
   }))
 
   return commits.data
-    .map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message, scopes))
+    .map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message, scopes, allowMergeCommits))
 }
 
 async function handlePullRequestChange (context) {
@@ -25,10 +26,11 @@ async function handlePullRequestChange (context) {
     titleOnly,
     commitsOnly,
     titleAndCommits,
-    scopes
+    scopes,
+    allowMergeCommits
   } = await getConfig(context, 'semantic.yml', DEFAULT_OPTS)
   const hasSemanticTitle = isSemanticMessage(title, scopes)
-  const hasSemanticCommits = await commitsAreSemantic(context, scopes, commitsOnly || titleAndCommits)
+  const hasSemanticCommits = await commitsAreSemantic(context, scopes, commitsOnly || titleAndCommits, allowMergeCommits)
 
   let isSemantic
 

--- a/lib/is-semantic-message.js
+++ b/lib/is-semantic-message.js
@@ -1,7 +1,10 @@
 const commitTypes = Object.keys(require('conventional-commit-types').types)
 const { validate } = require('parse-commit-message')
 
-module.exports = function isSemanticMessage (message, scopes) {
+module.exports = function isSemanticMessage (message, scopes, allowMergeCommits) {
+  const isMergeCommit = message && message.startsWith('Merge')
+  if (allowMergeCommits && isMergeCommit) return true
+
   const { error, value: commits } = validate(message, true)
 
   if (error) {


### PR DESCRIPTION
Github allow users to update branch of a pull request that is not update to date with target branch

If you do so, you have a merge commit in the PR: Merge branch 'master' into feature/ride-unicorns

What if we could allow this kind of commits with a specific option ?

TADA: `allowMergeCommits`: true is here !

This option is disable by default

-----
[View rendered README.md](https://github.com/clakech/semantic-pull-requests/blob/allowMerge/README.md)