### PR TITLE
test: verify isSemanticMessage allow merge commits

### DIFF
--- a/__tests__/handle-pull-request-change.js
+++ b/__tests__/handle-pull-request-change.js
@@ -406,6 +406,7 @@ describe('handlePullRequestChange', () => {
       const mock = nock('https://api.github.com')
         .get('/repos/sally/project-x/pulls/123/commits')
         .reply(200, [
+          ...semanticCommits(),
           { commit: { message: 'Merge branch \'master\' into feature/logout' } }
         ])
         .post('/repos/sally/project-x/statuses/abcdefg', expectedBody)
@@ -413,6 +414,9 @@ describe('handlePullRequestChange', () => {
         .get('/repos/sally/project-x/contents/.github/semantic.yml')
         .reply(200, getConfigResponse(`
           commitsOnly: true
+          scopes:
+            - scope1
+            - scope2
           allowMergeCommits: true
           `))
 

--- a/__tests__/is-semantic-message.js
+++ b/__tests__/is-semantic-message.js
@@ -1,21 +1,29 @@
 const isSemanticMessage = require('../lib/is-semantic-message')
 
-test('returns true when messages are semantic', () => {
-  expect(isSemanticMessage('fix: something')).toBe(true)
-})
+describe('isSemanticMessage', () => {
+  test('returns true when messages are semantic', () => {
+    expect(isSemanticMessage('fix: something')).toBe(true)
+  })
 
-test('allows parenthetical scope following the type', () => {
-  expect(isSemanticMessage('fix(subsystem): something')).toBe(true)
-})
+  test('allows parenthetical scope following the type', () => {
+    expect(isSemanticMessage('fix(subsystem): something')).toBe(true)
+  })
 
-test('returns false on bad input', () => {
-  expect(isSemanticMessage('')).toBe(false)
-  expect(isSemanticMessage(null)).toBe(false)
-  expect(isSemanticMessage('non-semantic commit message')).toBe(false)
-})
+  test('returns false on bad input', () => {
+    expect(isSemanticMessage('')).toBe(false)
+    expect(isSemanticMessage(null)).toBe(false)
+    expect(isSemanticMessage('non-semantic commit message')).toBe(false)
+  })
 
-test('should check message scope', () => {
-  expect(isSemanticMessage('fix(validScope): something', ['validScope'])).toBe(true)
-  expect(isSemanticMessage('fix(invalidScope): something', ['validScope'])).toBe(false)
-  expect(isSemanticMessage('fix(): something', ['validScope'])).toBe(false)
+  test('should check message scope', () => {
+    expect(isSemanticMessage('fix(validScope): something', ['validScope'])).toBe(true)
+    expect(isSemanticMessage('fix(invalidScope): something', ['validScope'])).toBe(false)
+    expect(isSemanticMessage('fix(): something', ['validScope'])).toBe(false)
+  })
+
+  test('allows merge commits', () => {
+    expect(isSemanticMessage('Merge branch \'master\' into patch-1', null, true)).toBe(true)
+
+    expect(isSemanticMessage('Merge refs/heads/master into angry-burritos/US-335', ['scope1'], true)).toBe(true)
+  })
 })


### PR DESCRIPTION
I face issue when testing latest feature allowing Merge Commits on my repos so I create more tests to verify the behaviour of the code. This does not solve my issues but those tests could help avoid regression later