### PR TITLE
feat: add squashMessage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,11 @@ titleAndCommits: true
 ```
 
 ```yml
+# Validate either the commit message (for single-commit PRs) or the PR title (for multiple commit PRs):
+squashMessage: true
+```
+
+```yml
 # You can define a list of valid scopes
 scopes:
   - scope1

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -7,16 +7,13 @@ const DEFAULT_OPTS = {
   titleOnly: false,
   commitsOnly: false,
   titleAndCommits: false,
+  squashMessage: false,
   scopes: null,
   allowMergeCommits: false
 }
 
-async function commitsAreSemantic (context, scopes, allCommits = false, allowMergeCommits) {
-  const commits = await context.github.pullRequests.getCommits(context.repo({
-    number: context.payload.pull_request.number
-  }))
-
-  return commits.data
+function commitsAreSemantic (commits, scopes, allCommits = false, allowMergeCommits) {
+  return commits
     .map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message, scopes, allowMergeCommits))
 }
 
@@ -27,14 +24,22 @@ async function handlePullRequestChange (context) {
     commitsOnly,
     titleAndCommits,
     scopes,
-    allowMergeCommits
+    allowMergeCommits,
+    squashMessage
   } = await getConfig(context, 'semantic.yml', DEFAULT_OPTS)
   const hasSemanticTitle = isSemanticMessage(title, scopes)
-  const hasSemanticCommits = await commitsAreSemantic(context, scopes, commitsOnly || titleAndCommits, allowMergeCommits)
+  const commitsResponse = await context.github.pullRequests.getCommits(context.repo({
+    number: context.payload.pull_request.number
+  }))
+  const commits = commitsResponse.data
+  const isSingleCommit = commits.length === 1
+  const hasSemanticCommits = commitsAreSemantic(commits, scopes, commitsOnly || titleAndCommits, allowMergeCommits)
 
   let isSemantic
 
-  if (titleOnly) {
+  if (squashMessage && isSingleCommit) {
+    isSemantic = isSemanticMessage(commits[0].message, scopes, allowMergeCommits)
+  } else if (titleOnly || (squashMessage && !isSingleCommit)) {
     isSemantic = hasSemanticTitle
   } else if (commitsOnly) {
     isSemantic = hasSemanticCommits
@@ -47,6 +52,8 @@ async function handlePullRequestChange (context) {
   const state = isSemantic ? 'success' : 'pending'
 
   function getDescription () {
+    if (!isSemantic && squashMessage && isSingleCommit) return 'make sure commit is semantic'
+    if (!isSemantic && squashMessage && !isSingleCommit) return 'add a semantic PR title'
     if (isSemantic && titleAndCommits) return 'ready to be merged, squashed or rebased'
     if (!isSemantic && titleAndCommits) return 'add a semantic commit AND PR title'
     if (hasSemanticTitle && !commitsOnly) return 'ready to be squashed'


### PR DESCRIPTION
This adds a `squashMessage` option which validates either:
- **if multiple commits**: the PR title should be semantic
- **if single commit**: the single commit message should be semantic

This fixes #17, but relies on the admin enforcing squash-merges only on the given repository. It's needed because of a quirk in the way GitHub handles squash-merges: when only one commit is present on a pull-request, that commit's title is used as the default message for the merge.

Per @frabonomi's [comment](https://github.com/probot/semantic-pull-requests/issues/17#issuecomment-459988168) I opted for the second option because of the particular nature of this deployed bot: I'm hesitant to make backward incompatible changes.

See also: https://github.com/sindresorhus/refined-github/issues/276

/cc @zeke, @kewah

-----
[View rendered README.md](https://github.com/christopherscott/semantic-pull-requests/blob/squash-message-option/README.md)