### PR TITLE
Revert "fix: set pending status on single-commit PRs with a solitary unsemantic commit"

### DIFF
--- a/__tests__/handle-pull-request-change.js
+++ b/__tests__/handle-pull-request-change.js
@@ -115,28 +115,6 @@ describe('handlePullRequestChange', () => {
       expect(mock.isDone()).toBe(true)
     })
 
-    test('sets `pending` status if PR has only one commit, and that commit is not semantic', async () => {
-      const context = buildContext()
-      context.payload.pull_request.title = 'fix: do a thing'
-      const expectedBody = {
-        state: 'pending',
-        target_url: 'https://github.com/probot/semantic-pull-requests',
-        description: 'Squashing a PR with only one commit will use that commit’s message. Please push an empty semantic commit.',
-        context: 'Semantic Pull Request'
-      }
-
-      const mock = nock('https://api.github.com')
-        .get('/repos/sally/project-x/pulls/123/commits')
-        .reply(200, singleUnsemanticCommit())
-        .post('/repos/sally/project-x/statuses/abcdefg', expectedBody)
-        .reply(200)
-        .get('/repos/sally/project-x/contents/.github/semantic.yml')
-        .reply(200, getConfigResponse())
-
-      await handlePullRequestChange(context)
-      expect(mock.isDone()).toBe(true)
-    })
-
     test('sets `success` status if PR has semantic title with available scope', async () => {
       const context = buildContext()
       context.payload.pull_request.title = 'fix(scope1): bananas'
@@ -544,12 +522,6 @@ describe('handlePullRequestChange', () => {
     expect(mock.isDone()).toBe(true)
   })
 })
-
-function singleUnsemanticCommit () {
-  return [
-    { commit: { message: 'fix something' } }
-  ]
-}
 
 function unsemanticCommits () {
   return [

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -11,15 +11,13 @@ const DEFAULT_OPTS = {
   allowMergeCommits: false
 }
 
-async function commitsAreSemantic (commits, scopes, allCommits = false, allowMergeCommits) {
-  return commits.map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message, scopes, allowMergeCommits))
-}
-
-async function getCommits (context) {
-  const { data } = await context.github.pullRequests.getCommits(context.repo({
+async function commitsAreSemantic (context, scopes, allCommits = false, allowMergeCommits) {
+  const commits = await context.github.pullRequests.getCommits(context.repo({
     number: context.payload.pull_request.number
   }))
-  return data
+
+  return commits.data
+    .map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message, scopes, allowMergeCommits))
 }
 
 async function handlePullRequestChange (context) {
@@ -32,11 +30,10 @@ async function handlePullRequestChange (context) {
     allowMergeCommits
   } = await getConfig(context, 'semantic.yml', DEFAULT_OPTS)
   const hasSemanticTitle = isSemanticMessage(title, scopes)
-  const commits = await getCommits(context)
-  const hasSemanticCommits = await commitsAreSemantic(commits, scopes, commitsOnly || titleAndCommits, allowMergeCommits)
-  const vanillaConfig = !titleOnly && !commitsOnly && !titleAndCommits
+  const hasSemanticCommits = await commitsAreSemantic(context, scopes, commitsOnly || titleAndCommits, allowMergeCommits)
 
   let isSemantic
+
   if (titleOnly) {
     isSemantic = hasSemanticTitle
   } else if (commitsOnly) {
@@ -44,13 +41,12 @@ async function handlePullRequestChange (context) {
   } else if (titleAndCommits) {
     isSemantic = hasSemanticTitle && hasSemanticCommits
   } else {
-    isSemantic = (hasSemanticTitle || hasSemanticCommits) && commits.length > 1
+    isSemantic = hasSemanticTitle || hasSemanticCommits
   }
 
   const state = isSemantic ? 'success' : 'pending'
 
   function getDescription () {
-    if (vanillaConfig && !isSemantic && commits.length === 1) return 'Squashing a PR with only one commit will use that commit’s message. Please push an empty semantic commit.'
     if (isSemantic && titleAndCommits) return 'ready to be merged, squashed or rebased'
     if (!isSemantic && titleAndCommits) return 'add a semantic commit AND PR title'
     if (hasSemanticTitle && !commitsOnly) return 'ready to be squashed'

--- a/lib/is-semantic-message.js
+++ b/lib/is-semantic-message.js
@@ -8,7 +8,7 @@ module.exports = function isSemanticMessage (message, scopes, allowMergeCommits)
   const { error, value: commits } = validate(message, true)
 
   if (error) {
-    if (process.env.NODE_ENV !== 'test') console.error(error)
+    console.error(error)
     return false
   }
 


### PR DESCRIPTION
Reverts probot/semantic-pull-requests#58

There's a bug. Let's revisit and try again: https://github.com/probot/semantic-pull-requests/pull/58#issuecomment-524688285

h/t @alanhchoi