### PR TITLE
feat: Support additional types

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ scopes:
 ```
 
 ```yml
-# By default types specified in commitizen/conventional-commit-types is used
+# By default types specified in commitizen/conventional-commit-types is used.
+# See: https://github.com/commitizen/conventional-commit-types/blob/v2.2.0/index.json
 # You can override the valid types
 types:
   - feat

--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ scopes:
 ```
 
 ```yml
+# By default types specified in commitizen/conventional-commit-types is used
+# You can override the valid types
+types:
+  - feat
+  - fix
+  - docs
+  - style
+  - refactor
+  - perf
+  - test
+  - build
+  - ci
+  - chore
+  - revert
+```
+
+```yml
 # Allow use of Merge commits (eg on github: "Merge branch 'master' into feature/ride-unicorns")
 # this is only relevant when using commitsOnly: true (or titleAndCommits: true)
 allowMergeCommits: true

--- a/__tests__/is-semantic-message.js
+++ b/__tests__/is-semantic-message.js
@@ -2,54 +2,28 @@ const isSemanticMessage = require('../lib/is-semantic-message')
 
 describe('isSemanticMessage', () => {
   test('returns true when messages are semantic', () => {
-    expect(isSemanticMessage('fix: something', ['fix'])).toBe(true)
+    expect(isSemanticMessage('fix: something')).toBe(true)
   })
 
   test('allows parenthetical scope following the type', () => {
-    expect(isSemanticMessage('fix(subsystem): something', ['fix'])).toBe(true)
+    expect(isSemanticMessage('fix(subsystem): something')).toBe(true)
   })
 
   test('returns false on bad input', () => {
-    expect(isSemanticMessage('', ['fix'])).toBe(false)
-    expect(isSemanticMessage(null, ['fix'])).toBe(false)
-    expect(isSemanticMessage('non-semantic commit message', ['fix'])).toBe(false)
+    expect(isSemanticMessage('')).toBe(false)
+    expect(isSemanticMessage(null)).toBe(false)
+    expect(isSemanticMessage('non-semantic commit message')).toBe(false)
   })
 
   test('should check message scope', () => {
-    expect(isSemanticMessage('fix(validScope): something', ['fix'], ['validScope'])).toBe(true)
-    expect(isSemanticMessage('fix(invalidScope): something', ['fix'], ['validScope'])).toBe(false)
-    expect(isSemanticMessage('fix(): something', ['fix'], ['validScope'])).toBe(false)
+    expect(isSemanticMessage('fix(validScope): something', ['validScope'])).toBe(true)
+    expect(isSemanticMessage('fix(invalidScope): something', ['validScope'])).toBe(false)
+    expect(isSemanticMessage('fix(): something', ['validScope'])).toBe(false)
   })
 
   test('allows merge commits', () => {
-    expect(isSemanticMessage('Merge branch \'master\' into patch-1', ['fix'], null, true)).toBe(true)
+    expect(isSemanticMessage('Merge branch \'master\' into patch-1', null, null, true)).toBe(true)
 
-    expect(isSemanticMessage('Merge refs/heads/master into angry-burritos/US-335', ['fix'], ['scope1'], true)).toBe(true)
-  })
-
-  test('should check for allowed types', () => {
-    const commonConventionalCommitType = [
-      'feat',
-      'fix',
-      'refactor'
-    ]
-
-    expect(isSemanticMessage('feat: Add something', commonConventionalCommitType)).toBe(true)
-    expect(isSemanticMessage('fix: Fix something', commonConventionalCommitType)).toBe(true)
-    expect(isSemanticMessage('refactor: Updated something', commonConventionalCommitType)).toBe(true)
-
-    const customConventionalCommitType = [
-      'feat',
-      'fix',
-      'refactor',
-      'alternative'
-    ]
-    expect(isSemanticMessage('alternative: Do alternative stuff', customConventionalCommitType)).toBe(true)
-    expect(isSemanticMessage('other: Do other stuff', customConventionalCommitType)).toBe(false)
-  })
-
-  test('should fail if invalid types variable is provided', () => {
-    expect(() => isSemanticMessage('fix: Do other stuff', null)).toThrowError(TypeError)
-    expect(() => isSemanticMessage('fix: Do other stuff', undefined)).toThrowError(TypeError)
+    expect(isSemanticMessage('Merge refs/heads/master into angry-burritos/US-335', ['scope1'], null, true)).toBe(true)
   })
 })

--- a/__tests__/is-semantic-message.js
+++ b/__tests__/is-semantic-message.js
@@ -26,4 +26,25 @@ describe('isSemanticMessage', () => {
 
     expect(isSemanticMessage('Merge refs/heads/master into angry-burritos/US-335', ['fix'], ['scope1'], true)).toBe(true)
   })
+
+  test('should check for allowed types', () => {
+    const commonConventionalCommitType = [
+      'feat',
+      'fix',
+      'refactor'
+    ]
+
+    expect(isSemanticMessage('feat: Add something', commonConventionalCommitType)).toBe(true)
+    expect(isSemanticMessage('fix: Fix something', commonConventionalCommitType)).toBe(true)
+    expect(isSemanticMessage('refactor: Updated something', commonConventionalCommitType)).toBe(true)
+
+    const customConventionalCommitType = [
+      'feat',
+      'fix',
+      'refactor',
+      'alternative'
+    ]
+    expect(isSemanticMessage('alternative: Do alternative stuff', customConventionalCommitType)).toBe(true)
+    expect(isSemanticMessage('other: Do other stuff', customConventionalCommitType)).toBe(false)
+  })
 })

--- a/__tests__/is-semantic-message.js
+++ b/__tests__/is-semantic-message.js
@@ -47,4 +47,9 @@ describe('isSemanticMessage', () => {
     expect(isSemanticMessage('alternative: Do alternative stuff', customConventionalCommitType)).toBe(true)
     expect(isSemanticMessage('other: Do other stuff', customConventionalCommitType)).toBe(false)
   })
+
+  test('should fail if invalid types variable is provided', () => {
+    expect(isSemanticMessage('fix: Do other stuff', null)).toThrowError(TypeError)
+    expect(isSemanticMessage('fix: Do other stuff', undefined)).toThrowError(TypeError)
+  })
 })

--- a/__tests__/is-semantic-message.js
+++ b/__tests__/is-semantic-message.js
@@ -27,3 +27,52 @@ describe('isSemanticMessage', () => {
     expect(isSemanticMessage('Merge refs/heads/master into angry-burritos/US-335', ['scope1'], null, true)).toBe(true)
   })
 })
+
+describe('isSemanticMessage - Handling validTypes', () => {
+  test('return true for all default types when validTypes is provided', () => {
+    expect(isSemanticMessage('feat: something')).toBe(true)
+    expect(isSemanticMessage('fix: something')).toBe(true)
+    expect(isSemanticMessage('docs: something')).toBe(true)
+    expect(isSemanticMessage('style: something')).toBe(true)
+    expect(isSemanticMessage('refactor: something')).toBe(true)
+    expect(isSemanticMessage('perf: something')).toBe(true)
+    expect(isSemanticMessage('test: something')).toBe(true)
+    expect(isSemanticMessage('build: something')).toBe(true)
+    expect(isSemanticMessage('ci: something')).toBe(true)
+    expect(isSemanticMessage('chore: something')).toBe(true)
+    expect(isSemanticMessage('revert: something')).toBe(true)
+  })
+
+  test('return false for none default types when validTypes is provided', () => {
+    expect(isSemanticMessage('alternative: something')).toBe(false)
+  })
+
+  test('return true for types included in supplied validTypes', () => {
+    const customConventionalCommitType = [
+      'alternative',
+      'improvement'
+    ]
+
+    expect(isSemanticMessage('alternative: something', null, customConventionalCommitType)).toBe(true)
+    expect(isSemanticMessage('improvement: something', null, customConventionalCommitType)).toBe(true)
+  })
+
+  test('return false for types NOT included in supplied validTypes', () => {
+    const customConventionalCommitType = [
+      'alternative',
+      'improvement'
+    ]
+
+    expect(isSemanticMessage('feat: something', null, customConventionalCommitType)).toBe(false)
+    expect(isSemanticMessage('fix: something', null, customConventionalCommitType)).toBe(false)
+    expect(isSemanticMessage('docs: something', null, customConventionalCommitType)).toBe(false)
+    expect(isSemanticMessage('style: something', null, customConventionalCommitType)).toBe(false)
+    expect(isSemanticMessage('refactor: something', null, customConventionalCommitType)).toBe(false)
+    expect(isSemanticMessage('perf: something', null, customConventionalCommitType)).toBe(false)
+    expect(isSemanticMessage('test: something', null, customConventionalCommitType)).toBe(false)
+    expect(isSemanticMessage('build: something', null, customConventionalCommitType)).toBe(false)
+    expect(isSemanticMessage('ci: something', null, customConventionalCommitType)).toBe(false)
+    expect(isSemanticMessage('chore: something', null, customConventionalCommitType)).toBe(false)
+    expect(isSemanticMessage('revert: something', null, customConventionalCommitType)).toBe(false)
+  })
+})

--- a/__tests__/is-semantic-message.js
+++ b/__tests__/is-semantic-message.js
@@ -49,7 +49,7 @@ describe('isSemanticMessage', () => {
   })
 
   test('should fail if invalid types variable is provided', () => {
-    expect(isSemanticMessage('fix: Do other stuff', null)).toThrowError(TypeError)
-    expect(isSemanticMessage('fix: Do other stuff', undefined)).toThrowError(TypeError)
+    expect(() => isSemanticMessage('fix: Do other stuff', null)).toThrowError(TypeError)
+    expect(() => isSemanticMessage('fix: Do other stuff', undefined)).toThrowError(TypeError)
   })
 })

--- a/__tests__/is-semantic-message.js
+++ b/__tests__/is-semantic-message.js
@@ -2,28 +2,28 @@ const isSemanticMessage = require('../lib/is-semantic-message')
 
 describe('isSemanticMessage', () => {
   test('returns true when messages are semantic', () => {
-    expect(isSemanticMessage('fix: something')).toBe(true)
+    expect(isSemanticMessage('fix: something', ['fix'])).toBe(true)
   })
 
   test('allows parenthetical scope following the type', () => {
-    expect(isSemanticMessage('fix(subsystem): something')).toBe(true)
+    expect(isSemanticMessage('fix(subsystem): something', ['fix'])).toBe(true)
   })
 
   test('returns false on bad input', () => {
-    expect(isSemanticMessage('')).toBe(false)
-    expect(isSemanticMessage(null)).toBe(false)
-    expect(isSemanticMessage('non-semantic commit message')).toBe(false)
+    expect(isSemanticMessage('', ['fix'])).toBe(false)
+    expect(isSemanticMessage(null, ['fix'])).toBe(false)
+    expect(isSemanticMessage('non-semantic commit message', ['fix'])).toBe(false)
   })
 
   test('should check message scope', () => {
-    expect(isSemanticMessage('fix(validScope): something', ['validScope'])).toBe(true)
-    expect(isSemanticMessage('fix(invalidScope): something', ['validScope'])).toBe(false)
-    expect(isSemanticMessage('fix(): something', ['validScope'])).toBe(false)
+    expect(isSemanticMessage('fix(validScope): something', ['fix'], ['validScope'])).toBe(true)
+    expect(isSemanticMessage('fix(invalidScope): something', ['fix'], ['validScope'])).toBe(false)
+    expect(isSemanticMessage('fix(): something', ['fix'], ['validScope'])).toBe(false)
   })
 
   test('allows merge commits', () => {
-    expect(isSemanticMessage('Merge branch \'master\' into patch-1', null, true)).toBe(true)
+    expect(isSemanticMessage('Merge branch \'master\' into patch-1', ['fix'], null, true)).toBe(true)
 
-    expect(isSemanticMessage('Merge refs/heads/master into angry-burritos/US-335', ['scope1'], true)).toBe(true)
+    expect(isSemanticMessage('Merge refs/heads/master into angry-burritos/US-335', ['fix'], ['scope1'], true)).toBe(true)
   })
 })

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -2,22 +2,24 @@ module.exports = handlePullRequestChange
 
 const isSemanticMessage = require('./is-semantic-message')
 const getConfig = require('probot-config')
+const commitTypes = Object.keys(require('conventional-commit-types').types)
 
 const DEFAULT_OPTS = {
   titleOnly: false,
   commitsOnly: false,
   titleAndCommits: false,
   scopes: null,
+  types: commitTypes,
   allowMergeCommits: false
 }
 
-async function commitsAreSemantic (context, scopes, allCommits = false, allowMergeCommits) {
+async function commitsAreSemantic (context, types, scopes, allCommits = false, allowMergeCommits) {
   const commits = await context.github.pullRequests.getCommits(context.repo({
     number: context.payload.pull_request.number
   }))
 
   return commits.data
-    .map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message, scopes, allowMergeCommits))
+    .map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message, types, scopes, allowMergeCommits))
 }
 
 async function handlePullRequestChange (context) {
@@ -27,10 +29,11 @@ async function handlePullRequestChange (context) {
     commitsOnly,
     titleAndCommits,
     scopes,
+    types,
     allowMergeCommits
   } = await getConfig(context, 'semantic.yml', DEFAULT_OPTS)
-  const hasSemanticTitle = isSemanticMessage(title, scopes)
-  const hasSemanticCommits = await commitsAreSemantic(context, scopes, commitsOnly || titleAndCommits, allowMergeCommits)
+  const hasSemanticTitle = isSemanticMessage(title, types, scopes)
+  const hasSemanticCommits = await commitsAreSemantic(context, types, scopes, commitsOnly || titleAndCommits, allowMergeCommits)
 
   let isSemantic
 

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -2,24 +2,23 @@ module.exports = handlePullRequestChange
 
 const isSemanticMessage = require('./is-semantic-message')
 const getConfig = require('probot-config')
-const commitTypes = Object.keys(require('conventional-commit-types').types)
 
 const DEFAULT_OPTS = {
   titleOnly: false,
   commitsOnly: false,
   titleAndCommits: false,
   scopes: null,
-  types: commitTypes,
+  types: null,
   allowMergeCommits: false
 }
 
-async function commitsAreSemantic (context, types, scopes, allCommits = false, allowMergeCommits) {
+async function commitsAreSemantic (context, scopes, types, allCommits = false, allowMergeCommits) {
   const commits = await context.github.pullRequests.getCommits(context.repo({
     number: context.payload.pull_request.number
   }))
 
   return commits.data
-    .map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message, types, scopes, allowMergeCommits))
+    .map(element => element.commit)[allCommits ? 'every' : 'some'](commit => isSemanticMessage(commit.message, scopes, types, allowMergeCommits))
 }
 
 async function handlePullRequestChange (context) {
@@ -32,8 +31,8 @@ async function handlePullRequestChange (context) {
     types,
     allowMergeCommits
   } = await getConfig(context, 'semantic.yml', DEFAULT_OPTS)
-  const hasSemanticTitle = isSemanticMessage(title, types, scopes)
-  const hasSemanticCommits = await commitsAreSemantic(context, types, scopes, commitsOnly || titleAndCommits, allowMergeCommits)
+  const hasSemanticTitle = isSemanticMessage(title, scopes, types)
+  const hasSemanticCommits = await commitsAreSemantic(context, scopes, types, commitsOnly || titleAndCommits, allowMergeCommits)
 
   let isSemantic
 

--- a/lib/is-semantic-message.js
+++ b/lib/is-semantic-message.js
@@ -1,7 +1,7 @@
 const commitTypes = Object.keys(require('conventional-commit-types').types)
 const { validate } = require('parse-commit-message')
 
-module.exports = function isSemanticMessage (message, scopes, allowMergeCommits) {
+module.exports = function isSemanticMessage (message, validScopes, allowMergeCommits) {
   const isMergeCommit = message && message.startsWith('Merge')
   if (allowMergeCommits && isMergeCommit) return true
 
@@ -14,6 +14,6 @@ module.exports = function isSemanticMessage (message, scopes, allowMergeCommits)
 
   const [result] = commits
   const { scope, type } = result.header
-  const isScopeValid = !scopes || !scope || scopes.includes(scope)
+  const isScopeValid = !validScopes || !scope || validScopes.includes(scope)
   return commitTypes.includes(type) && isScopeValid
 }

--- a/lib/is-semantic-message.js
+++ b/lib/is-semantic-message.js
@@ -1,6 +1,7 @@
+const commitTypes = Object.keys(require('conventional-commit-types').types)
 const { validate } = require('parse-commit-message')
 
-module.exports = function isSemanticMessage (message, validTypes, validScopes, allowMergeCommits) {
+module.exports = function isSemanticMessage (message, validScopes, validTypes, allowMergeCommits) {
   const isMergeCommit = message && message.startsWith('Merge')
   if (allowMergeCommits && isMergeCommit) return true
 
@@ -14,5 +15,5 @@ module.exports = function isSemanticMessage (message, validTypes, validScopes, a
   const [result] = commits
   const { scope, type } = result.header
   const isScopeValid = !validScopes || !scope || validScopes.includes(scope)
-  return validTypes.includes(type) && isScopeValid
+  return (validTypes || commitTypes).includes(type) && isScopeValid
 }

--- a/lib/is-semantic-message.js
+++ b/lib/is-semantic-message.js
@@ -1,7 +1,6 @@
-const commitTypes = Object.keys(require('conventional-commit-types').types)
 const { validate } = require('parse-commit-message')
 
-module.exports = function isSemanticMessage (message, validScopes, allowMergeCommits) {
+module.exports = function isSemanticMessage (message, validTypes, validScopes, allowMergeCommits) {
   const isMergeCommit = message && message.startsWith('Merge')
   if (allowMergeCommits && isMergeCommit) return true
 
@@ -15,5 +14,5 @@ module.exports = function isSemanticMessage (message, validScopes, allowMergeCom
   const [result] = commits
   const { scope, type } = result.header
   const isScopeValid = !validScopes || !scope || validScopes.includes(scope)
-  return commitTypes.includes(type) && isScopeValid
+  return validTypes.includes(type) && isScopeValid
 }


### PR DESCRIPTION
Related to #34

## Add support for custom types

### Default behaviour
By default the type specified in https://github.com/commitizen/conventional-commit-types/blob/01a66a9c4946f51c3018eef4c26cef79ed82205e/index.json will still be used.

### Custom Behaviour
Additional types can be specified by adding additional key `types` in `semantic.yml`.
This key should receive an array of type strings.

This will replace the default conventional commit types.

```yml
types:
  - feat
  - fix
  - improvement
  - alternative
  - other
```

## Misc
- Added additional params to `isSemanticMessage`
- Added additional tests
- Added additional section for this PR in README

-----
[View rendered README.md](https://github.com/amoshydra/semantic-pull-requests/blob/additional-types/README.md)