### PR TITLE
feat: add config option to validate any commit instead of all commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ titleAndCommits: true
 ```
 
 ```yml
+# Require at least one commit to be valid
+# this is only relevant when using commitsOnly: true or titleAndCommits: true,
+# which validate all commits by default
+anyCommit: true
+```
+
+```yml
 # You can define a list of valid scopes
 scopes:
   - scope1

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -7,6 +7,7 @@ const DEFAULT_OPTS = {
   titleOnly: false,
   commitsOnly: false,
   titleAndCommits: false,
+  anyCommit: false,
   scopes: null,
   types: null,
   allowMergeCommits: false
@@ -27,12 +28,13 @@ async function handlePullRequestChange (context) {
     titleOnly,
     commitsOnly,
     titleAndCommits,
+    anyCommit,
     scopes,
     types,
     allowMergeCommits
   } = await getConfig(context, 'semantic.yml', DEFAULT_OPTS)
   const hasSemanticTitle = isSemanticMessage(title, scopes, types)
-  const hasSemanticCommits = await commitsAreSemantic(context, scopes, types, commitsOnly || titleAndCommits, allowMergeCommits)
+  const hasSemanticCommits = await commitsAreSemantic(context, scopes, types, (commitsOnly || titleAndCommits) && !anyCommit, allowMergeCommits)
 
   let isSemantic
 
@@ -54,6 +56,7 @@ async function handlePullRequestChange (context) {
     if (hasSemanticTitle && !commitsOnly) return 'ready to be squashed'
     if (hasSemanticCommits && !titleOnly) return 'ready to be merged or rebased'
     if (titleOnly) return 'add a semantic PR title'
+    if (commitsOnly && anyCommit) return 'add a semantic commit'
     if (commitsOnly) return 'make sure every commit is semantic'
     return 'add a semantic commit or PR title'
   }


### PR DESCRIPTION
My organization would like to be able to validate PRs using PR title and any (but not every) commit.
This adds an `anyCommit` config option that makes this possible (when used in conjunction with `titleAndCommits: true` or `commitsOnly: true`).

I believe this addresses #41 

-----
[View rendered README.md](https://github.com/ccangialose/semantic-pull-requests/blob/41/add-any-commit-config-option/README.md)